### PR TITLE
fixup! mt6768-common: overlay: Disable VoWiFi service by default

### DIFF
--- a/rro_overlays/CarrierConfigOverlayMT6768/res/xml/vendor.xml
+++ b/rro_overlays/CarrierConfigOverlayMT6768/res/xml/vendor.xml
@@ -46,7 +46,7 @@
         <boolean name="carrier_allow_transfer_ims_call_bool" value="true" />
     </carrier_config>
     <carrier_config mcc="202" mnc="1">
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <int name="carrier_default_wfc_ims_roaming_mode_int" value="1" />
         <string name="default_vm_number_string">+306971000123</string>
         <boolean name="show_ims_registration_status_bool" value="true" />
@@ -83,7 +83,7 @@
     <carrier_config mcc="204" mnc="4">
         <string name="default_vm_number_string">+31654501233</string>
         <boolean name="voicemail_notification_persistent_bool" value="true" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="hide_enhanced_4g_lte_bool" value="true" />
         <boolean name="editable_enhanced_4g_lte_bool" value="false" />
         <boolean name="enhanced_4g_lte_on_by_default_bool" value="true" />
@@ -92,7 +92,7 @@
         <boolean name="editable_wfc_mode_bool" value="true" />
     </carrier_config>
     <carrier_config mcc="204" mnc="8">
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="204" mnc="20">
         <string name="default_vm_number_string">+31624001233</string>
@@ -103,7 +103,7 @@
     <carrier_config mcc="206" mnc="10">
         <boolean name="carrier_volte_available_bool" value="true" />
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <string-array name="carrier_metered_apn_types_strings" num="3">
             <item value="default" />
             <item value="dun" />
@@ -130,7 +130,7 @@
         <boolean name="carrier_vt_available_bool" value="true" />
     </carrier_config>
     <carrier_config mcc="206" mnc="1">
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="208" mnc="01">
         <boolean name="carrier_volte_available_bool" value="true" />
@@ -333,11 +333,11 @@
     <carrier_config mcc="216" mnc="1">
         <boolean name="hide_enhanced_4g_lte_bool" value="true" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="216" mnc="3">
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="hide_enhanced_4g_lte_bool" value="true" />
         <boolean name="editable_enhanced_4g_lte_bool" value="false" />
     </carrier_config>
@@ -350,7 +350,7 @@
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
         <int name="carrier_default_wfc_ims_mode_int" value="10" />
         <int name="carrier_default_wfc_ims_roaming_mode_int" value="10" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
         <int name="carrier_default_wfc_ims_roaming_mode_int" value="1" />
         <boolean name="editable_wfc_roaming_mode_bool" value="true" />
@@ -377,7 +377,7 @@
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
         <int name="carrier_default_wfc_ims_mode_int" value="10" />
         <int name="carrier_default_wfc_ims_roaming_mode_int" value="10" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
         <int name="carrier_default_wfc_ims_roaming_mode_int" value="1" />
         <boolean name="editable_wfc_roaming_mode_bool" value="true" />
@@ -431,12 +431,12 @@
     <carrier_config mcc="222" mnc="88">
         <boolean name="carrier_volte_available_bool" value="true" />
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="222" mnc="99">
         <boolean name="carrier_volte_available_bool" value="true" />
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="222" mnc="35">
         <boolean name="carrier_volte_available_bool" value="true" />
@@ -465,7 +465,7 @@
         <boolean name="enhanced_4g_lte_on_by_default_bool" value="true" />
     </carrier_config>
     <carrier_config mcc="222" mnc="1">
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="hide_enhanced_4g_lte_bool" value="true" />
         <boolean name="editable_enhanced_4g_lte_bool" value="false" />
         <boolean name="enhanced_4g_lte_on_by_default_bool" value="true" />
@@ -548,7 +548,7 @@
     </carrier_config>
     <carrier_config mcc="226" mnc="5">
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="editable_wfc_roaming_mode_bool" value="true" />
     </carrier_config>
     <carrier_config mcc="228" mnc="02">
@@ -562,7 +562,7 @@
         <int name="carrier_default_wfc_ims_mode_int" value="10" />
     </carrier_config>
     <carrier_config mcc="228" mnc="1">
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="editable_wfc_mode_bool" value="true" />
     </carrier_config>
     <carrier_config mcc="230" mnc="02">
@@ -640,7 +640,7 @@
     </carrier_config>
     <carrier_config mcc="231" mnc="3">
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="231" mnc="6">
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
@@ -682,7 +682,7 @@
         <boolean name="carrier_vt_available_bool" value="true" />
         <boolean name="hide_enhanced_4g_lte_bool" value="true" />
         <boolean name="editable_enhanced_4g_lte_bool" value="false" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="carrier_default_data_roaming_enabled_bool" value="true" />
         <string-array name="non_roaming_operator_string_array" num="1">
             <item value="23203" />
@@ -695,7 +695,7 @@
         <boolean name="carrier_vt_available_bool" value="true" />
         <boolean name="hide_enhanced_4g_lte_bool" value="true" />
         <boolean name="editable_enhanced_4g_lte_bool" value="false" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="carrier_default_data_roaming_enabled_bool" value="true" />
         <string-array name="non_roaming_operator_string_array" num="1">
             <item value="23203" />
@@ -708,7 +708,7 @@
         <boolean name="carrier_vt_available_bool" value="true" />
         <boolean name="hide_enhanced_4g_lte_bool" value="true" />
         <boolean name="editable_enhanced_4g_lte_bool" value="false" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="carrier_default_data_roaming_enabled_bool" value="true" />
         <string-array name="non_roaming_operator_string_array" num="1">
             <item value="23203" />
@@ -718,7 +718,7 @@
     <carrier_config mcc="232" mnc="03">
         <boolean name="carrier_volte_available_bool" value="true" />
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <int name="carrier_default_wfc_ims_roaming_mode_int" value="1" />
         <boolean name="editable_wfc_roaming_mode_bool" value="true" />
         <string name="default_vm_number_string">+436762200</string>
@@ -742,7 +742,7 @@
     <carrier_config mcc="232" mnc="07">
         <boolean name="carrier_volte_available_bool" value="true" />
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <int name="carrier_default_wfc_ims_roaming_mode_int" value="1" />
         <boolean name="editable_wfc_roaming_mode_bool" value="true" />
         <string name="default_vm_number_string">+436762200</string>
@@ -799,7 +799,7 @@
     <carrier_config mcc="234" mnc="20">
         <boolean name="carrier_volte_available_bool" value="true" />
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="editable_wfc_mode_bool" value="false" />
         <boolean name="display_hd_audio_property_bool" value="false" />
         <boolean name="hide_enhanced_4g_lte_bool" value="true" />
@@ -820,15 +820,15 @@
     <carrier_config mcc="234" mnc="10">
         <boolean name="carrier_volte_available_bool" value="true" />
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="234" mnc="38">
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
         <int name="wfc_spn_format_idx_int" value="1" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="235" mnc="94">
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="editable_wfc_mode_bool" value="false" />
         <boolean name="display_hd_audio_property_bool" value="false" />
         <boolean name="hide_enhanced_4g_lte_bool" value="true" />
@@ -838,7 +838,7 @@
     <carrier_config mcc="238" mnc="20">
         <boolean name="carrier_volte_available_bool" value="true" />
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <string-array name="carrier_metered_apn_types_strings" num="3">
             <item value="default" />
             <item value="dun" />
@@ -859,7 +859,7 @@
         <boolean name="carrier_vt_available_bool" value="true" />
     </carrier_config>
     <carrier_config mcc="238" mnc="1">
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="238" mnc="6">
         <string-array name="non_roaming_operator_string_array" num="1">
@@ -867,10 +867,10 @@
         </string-array>
     </carrier_config>
     <carrier_config mcc="238" mnc="2">
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="238" mnc="30">
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <string-array name="carrier_metered_apn_types_strings" num="3">
             <item value="default" />
             <item value="dun" />
@@ -899,7 +899,7 @@
     <carrier_config mcc="240" mnc="2">
         <boolean name="hide_enhanced_4g_lte_bool" value="true" />
         <boolean name="editable_enhanced_4g_lte_bool" value="false" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <int name="carrier_default_wfc_ims_roaming_mode_int" value="2" />
         <boolean name="editable_wfc_mode_bool" value="false" />
         <string-array name="carrier_metered_apn_types_strings" num="3">
@@ -909,7 +909,7 @@
         </string-array>
     </carrier_config>
     <carrier_config mcc="240" mnc="7">
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="240" mnc="8">
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
@@ -947,7 +947,7 @@
     <carrier_config mcc="242" mnc="14">
         <boolean name="carrier_volte_available_bool" value="true" />
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="editable_wfc_roaming_mode_bool" value="true" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
     </carrier_config>
@@ -970,7 +970,7 @@
     <carrier_config mcc="244" mnc="91">
         <boolean name="carrier_volte_available_bool" value="true" />
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="editable_wfc_roaming_mode_bool" value="true" />
         <string-array name="carrier_metered_apn_types_strings" num="3">
             <item value="default" />
@@ -1011,7 +1011,7 @@
         <boolean name="carrier_vt_available_bool" value="true" />
     </carrier_config>
     <carrier_config mcc="246" mnc="1">
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <string-array name="carrier_metered_apn_types_strings" num="3">
             <item value="default" />
             <item value="dun" />
@@ -1052,7 +1052,7 @@
         <boolean name="carrier_vt_available_bool" value="true" />
     </carrier_config>
     <carrier_config mcc="248" mnc="1">
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <string-array name="carrier_metered_apn_types_strings" num="3">
             <item value="default" />
             <item value="dun" />
@@ -1078,7 +1078,7 @@
         <boolean name="carrier_volte_available_bool" value="true" />
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
         <boolean name="carrier_vt_available_bool" value="true" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="250" mnc="50">
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
@@ -1164,7 +1164,7 @@
         <int name="wfc_spn_format_idx_int" value="1" />
     </carrier_config>
     <carrier_config mcc="260" mnc="2">
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
         <int name="carrier_default_wfc_ims_roaming_mode_int" value="1" />
         <boolean name="editable_wfc_roaming_mode_bool" value="true" />
@@ -1275,7 +1275,7 @@
         <int name="carrier_default_wfc_ims_roaming_mode_int" value="10" />
         <boolean name="editable_wfc_mode_bool" value="false" />
         <boolean name="editable_wfc_roaming_mode_bool" value="false" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <int name="carrier_default_wfc_ims_roaming_mode_int" value="2" />
         <string name="default_vm_number_string">3311</string>
         <boolean name="show_ims_registration_status_bool" value="true" />
@@ -1303,7 +1303,7 @@
         <int name="carrier_default_wfc_ims_roaming_mode_int" value="10" />
         <boolean name="editable_wfc_mode_bool" value="false" />
         <boolean name="editable_wfc_roaming_mode_bool" value="false" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <int name="carrier_default_wfc_ims_roaming_mode_int" value="2" />
         <string name="default_vm_number_string">3311</string>
         <boolean name="show_ims_registration_status_bool" value="true" />
@@ -1331,7 +1331,7 @@
         <int name="carrier_default_wfc_ims_roaming_mode_int" value="10" />
         <boolean name="editable_wfc_mode_bool" value="false" />
         <boolean name="editable_wfc_roaming_mode_bool" value="false" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <int name="carrier_default_wfc_ims_roaming_mode_int" value="2" />
         <string name="default_vm_number_string">3311</string>
         <boolean name="show_ims_registration_status_bool" value="true" />
@@ -1493,7 +1493,7 @@
     </carrier_config>
     <carrier_config mcc="272" mnc="3">
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="272" mnc="5">
         <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
@@ -1517,7 +1517,7 @@
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
         <boolean name="carrier_vt_available_bool" value="true" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="280" mnc="10">
         <boolean name="carrier_volte_available_bool" value="true" />
@@ -1531,7 +1531,7 @@
         </string-array>
     </carrier_config>
     <carrier_config mcc="283" mnc="5">
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
     </carrier_config>
     <carrier_config mcc="284" mnc="03">
@@ -1546,7 +1546,7 @@
         <boolean name="carrier_vt_available_bool" value="true" />
     </carrier_config>
     <carrier_config mcc="284" mnc="3">
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="286" mnc="02">
         <boolean name="carrier_volte_available_bool" value="true" />
@@ -1564,18 +1564,18 @@
         <boolean name="carrier_vt_available_bool" value="true" />
     </carrier_config>
     <carrier_config mcc="286" mnc="3">
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="hide_enhanced_4g_lte_bool" value="true" />
         <boolean name="editable_enhanced_4g_lte_bool" value="false" />
         <boolean name="enhanced_4g_lte_on_by_default_bool" value="true" />
     </carrier_config>
     <carrier_config mcc="286" mnc="1">
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="hide_enhanced_4g_lte_bool" value="true" />
     </carrier_config>
     <carrier_config mcc="286" mnc="2">
         <boolean name="hide_enhanced_4g_lte_bool" value="true" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <string-array name="carrier_metered_apn_types_strings" num="3">
             <item value="default" />
             <item value="dun" />
@@ -1591,8 +1591,8 @@
     <carrier_config mcc="293" mnc="41">
         <boolean name="carrier_volte_available_bool" value="true" />
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="hide_enhanced_4g_lte_bool" value="true" />
         <boolean name="editable_enhanced_4g_lte_bool" value="false" />
         <boolean name="enhanced_4g_lte_on_by_default_bool" value="true" />
@@ -1609,7 +1609,7 @@
         <boolean name="carrier_volte_available_bool" value="true" />
         <boolean name="carrier_vt_available_bool" value="true" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="294" mnc="01">
         <boolean name="carrier_volte_available_bool" value="true" />
@@ -1769,7 +1769,7 @@
     <carrier_config mcc="330" mnc="110">
         <string name="default_vm_number_string">*86</string>
         <boolean name="editable_voicemail_number_setting_bool" value="false" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="is_ims_conference_size_enforced_bool" value="true" />
         <int name="ims_conference_size_limit_int" value="6" />
         <boolean name="display_hd_audio_property_bool" value="false" />
@@ -1782,7 +1782,7 @@
         <boolean name="editable_voicemail_number_setting_bool" value="false" />
         <boolean name="voicemail_notification_persistent_bool" value="true" />
         <boolean name="display_hd_audio_property_bool" value="false" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <int name="carrier_default_wfc_ims_roaming_mode_int" value="1" />
         <boolean name="editable_wfc_mode_bool" value="false" />
         <boolean name="is_ims_conference_size_enforced_bool" value="true" />
@@ -1795,7 +1795,7 @@
         <boolean name="editable_voicemail_number_setting_bool" value="false" />
         <boolean name="voicemail_notification_persistent_bool" value="true" />
         <boolean name="display_hd_audio_property_bool" value="false" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <int name="carrier_default_wfc_ims_roaming_mode_int" value="1" />
         <boolean name="editable_wfc_mode_bool" value="false" />
         <boolean name="is_ims_conference_size_enforced_bool" value="true" />
@@ -1825,7 +1825,7 @@
         <boolean name="show_iccid_in_sim_status_bool" value="true" />
         <boolean name="voicemail_notification_persistent_bool" value="true" />
         <boolean name="gsm_cdma_calls_can_be_hd_audio" value="true" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="carrier_default_data_roaming_enabled_bool" value="true" />
         <string-array name="non_roaming_operator_string_array" num="2">
             <item value="334020" />
@@ -1838,7 +1838,7 @@
         <boolean name="show_iccid_in_sim_status_bool" value="true" />
         <boolean name="voicemail_notification_persistent_bool" value="true" />
         <boolean name="gsm_cdma_calls_can_be_hd_audio" value="true" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="carrier_default_data_roaming_enabled_bool" value="true" />
         <string-array name="non_roaming_operator_string_array" num="2">
             <item value="334020" />
@@ -1865,7 +1865,7 @@
     <carrier_config mcc="370" mnc="2">
         <string name="default_vm_number_string">*99</string>
         <boolean name="editable_voicemail_number_setting_bool" value="false" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="editable_wfc_mode_bool" value="false" />
         <boolean name="is_ims_conference_size_enforced_bool" value="true" />
         <int name="ims_conference_size_limit_int" value="6" />
@@ -1883,7 +1883,7 @@
     </carrier_config>
     <carrier_config mcc="401" mnc="77">
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="404" mnc="02">
         <boolean name="carrier_volte_available_bool" value="true" />
@@ -1893,126 +1893,126 @@
         <boolean name="carrier_vt_available_bool" value="true" />
         <boolean name="editable_wfc_mode_bool" value="true" />
         <boolean name="editable_wfc_mode_bool" value="false" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="404" mnc="03">
         <boolean name="carrier_volte_available_bool" value="true" />
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
         <boolean name="carrier_vt_available_bool" value="true" />
         <boolean name="editable_wfc_mode_bool" value="false" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="404" mnc="10">
         <boolean name="carrier_volte_available_bool" value="true" />
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
         <boolean name="carrier_vt_available_bool" value="true" />
         <boolean name="editable_wfc_mode_bool" value="false" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="404" mnc="16">
         <boolean name="carrier_volte_available_bool" value="true" />
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
         <boolean name="carrier_vt_available_bool" value="true" />
         <boolean name="editable_wfc_mode_bool" value="false" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="404" mnc="31">
         <boolean name="carrier_volte_available_bool" value="true" />
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
         <boolean name="carrier_vt_available_bool" value="true" />
         <boolean name="editable_wfc_mode_bool" value="false" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="404" mnc="40">
         <boolean name="carrier_volte_available_bool" value="true" />
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
         <boolean name="carrier_vt_available_bool" value="true" />
         <boolean name="editable_wfc_mode_bool" value="false" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="404" mnc="45">
         <boolean name="carrier_volte_available_bool" value="true" />
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
         <boolean name="carrier_vt_available_bool" value="true" />
         <boolean name="editable_wfc_mode_bool" value="false" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="404" mnc="49">
         <boolean name="carrier_volte_available_bool" value="true" />
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
         <boolean name="carrier_vt_available_bool" value="true" />
         <boolean name="editable_wfc_mode_bool" value="false" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="404" mnc="70">
         <boolean name="carrier_volte_available_bool" value="true" />
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
         <boolean name="carrier_vt_available_bool" value="true" />
         <boolean name="editable_wfc_mode_bool" value="false" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="404" mnc="90">
         <boolean name="carrier_volte_available_bool" value="true" />
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
         <boolean name="carrier_vt_available_bool" value="true" />
         <boolean name="editable_wfc_mode_bool" value="false" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="404" mnc="92">
         <boolean name="carrier_volte_available_bool" value="true" />
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
         <boolean name="carrier_vt_available_bool" value="true" />
         <boolean name="editable_wfc_mode_bool" value="false" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="404" mnc="93">
         <boolean name="carrier_volte_available_bool" value="true" />
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
         <boolean name="carrier_vt_available_bool" value="true" />
         <boolean name="editable_wfc_mode_bool" value="false" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="404" mnc="94">
         <boolean name="carrier_volte_available_bool" value="true" />
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
         <boolean name="carrier_vt_available_bool" value="true" />
         <boolean name="editable_wfc_mode_bool" value="false" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="404" mnc="95">
         <boolean name="carrier_volte_available_bool" value="true" />
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
         <boolean name="carrier_vt_available_bool" value="true" />
         <boolean name="editable_wfc_mode_bool" value="false" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="404" mnc="96">
         <boolean name="carrier_volte_available_bool" value="true" />
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
         <boolean name="carrier_vt_available_bool" value="true" />
         <boolean name="editable_wfc_mode_bool" value="false" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="404" mnc="97">
         <boolean name="carrier_volte_available_bool" value="true" />
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
         <boolean name="carrier_vt_available_bool" value="true" />
         <boolean name="editable_wfc_mode_bool" value="false" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="404" mnc="98">
         <boolean name="carrier_volte_available_bool" value="true" />
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
         <boolean name="carrier_vt_available_bool" value="true" />
         <boolean name="editable_wfc_mode_bool" value="false" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="404" mnc="04">
         <boolean name="carrier_volte_available_bool" value="true" />
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
         <boolean name="carrier_vt_available_bool" value="true" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="editable_wfc_mode_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="404" mnc="07">
@@ -2020,7 +2020,7 @@
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
         <boolean name="carrier_vt_available_bool" value="true" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="editable_wfc_mode_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="404" mnc="12">
@@ -2028,7 +2028,7 @@
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
         <boolean name="carrier_vt_available_bool" value="true" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="editable_wfc_mode_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="404" mnc="14">
@@ -2036,7 +2036,7 @@
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
         <boolean name="carrier_vt_available_bool" value="true" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="editable_wfc_mode_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="404" mnc="19">
@@ -2044,7 +2044,7 @@
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
         <boolean name="carrier_vt_available_bool" value="true" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="editable_wfc_mode_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="404" mnc="22">
@@ -2052,7 +2052,7 @@
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
         <boolean name="carrier_vt_available_bool" value="true" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="editable_wfc_mode_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="404" mnc="24">
@@ -2060,7 +2060,7 @@
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
         <boolean name="carrier_vt_available_bool" value="true" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="editable_wfc_mode_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="404" mnc="44">
@@ -2068,7 +2068,7 @@
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
         <boolean name="carrier_vt_available_bool" value="true" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="editable_wfc_mode_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="404" mnc="56">
@@ -2076,7 +2076,7 @@
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
         <boolean name="carrier_vt_available_bool" value="true" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="editable_wfc_mode_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="404" mnc="78">
@@ -2084,7 +2084,7 @@
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
         <boolean name="carrier_vt_available_bool" value="true" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="editable_wfc_mode_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="404" mnc="82">
@@ -2092,7 +2092,7 @@
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
         <boolean name="carrier_vt_available_bool" value="true" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="editable_wfc_mode_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="404" mnc="87">
@@ -2100,7 +2100,7 @@
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
         <boolean name="carrier_vt_available_bool" value="true" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="editable_wfc_mode_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="404" mnc="89">
@@ -2108,7 +2108,7 @@
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
         <boolean name="carrier_vt_available_bool" value="true" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="editable_wfc_mode_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="404" mnc="01">
@@ -2116,7 +2116,7 @@
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
         <boolean name="carrier_vt_available_bool" value="true" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="editable_wfc_mode_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="404" mnc="05">
@@ -2124,7 +2124,7 @@
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
         <boolean name="carrier_vt_available_bool" value="true" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="editable_wfc_mode_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="404" mnc="11">
@@ -2132,7 +2132,7 @@
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
         <boolean name="carrier_vt_available_bool" value="true" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="editable_wfc_mode_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="404" mnc="13">
@@ -2140,7 +2140,7 @@
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
         <boolean name="carrier_vt_available_bool" value="true" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="editable_wfc_mode_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="404" mnc="15">
@@ -2148,7 +2148,7 @@
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
         <boolean name="carrier_vt_available_bool" value="true" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="editable_wfc_mode_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="404" mnc="20">
@@ -2156,7 +2156,7 @@
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
         <boolean name="carrier_vt_available_bool" value="true" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="editable_wfc_mode_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="404" mnc="27">
@@ -2164,7 +2164,7 @@
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
         <boolean name="carrier_vt_available_bool" value="true" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="editable_wfc_mode_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="404" mnc="30">
@@ -2172,7 +2172,7 @@
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
         <boolean name="carrier_vt_available_bool" value="true" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="editable_wfc_mode_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="404" mnc="43">
@@ -2180,7 +2180,7 @@
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
         <boolean name="carrier_vt_available_bool" value="true" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="editable_wfc_mode_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="404" mnc="46">
@@ -2188,7 +2188,7 @@
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
         <boolean name="carrier_vt_available_bool" value="true" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="editable_wfc_mode_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="404" mnc="60">
@@ -2196,7 +2196,7 @@
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
         <boolean name="carrier_vt_available_bool" value="true" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="editable_wfc_mode_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="404" mnc="84">
@@ -2204,7 +2204,7 @@
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
         <boolean name="carrier_vt_available_bool" value="true" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="editable_wfc_mode_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="404" mnc="86">
@@ -2212,7 +2212,7 @@
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
         <boolean name="carrier_vt_available_bool" value="true" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="editable_wfc_mode_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="404" mnc="88">
@@ -2220,7 +2220,7 @@
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
         <boolean name="carrier_vt_available_bool" value="true" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="editable_wfc_mode_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="405" mnc="840">
@@ -2232,7 +2232,7 @@
         <boolean name="editable_wfc_mode_bool" value="true" />
         <boolean name="carrier_use_ims_first_for_emergency_bool" value="true" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="editable_wfc_mode_bool" value="false" />
         <boolean name="carrier_name_override_bool" value="false" />
         <string name="carrier_name_string" />
@@ -2244,7 +2244,7 @@
         <boolean name="carrier_vt_available_bool" value="true" />
         <boolean name="carrier_use_ims_first_for_emergency_bool" value="true" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="editable_wfc_mode_bool" value="false" />
         <boolean name="carrier_name_override_bool" value="false" />
         <string name="carrier_name_string" />
@@ -2256,7 +2256,7 @@
         <boolean name="carrier_vt_available_bool" value="true" />
         <boolean name="carrier_use_ims_first_for_emergency_bool" value="true" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="editable_wfc_mode_bool" value="false" />
         <boolean name="carrier_name_override_bool" value="false" />
         <string name="carrier_name_string" />
@@ -2268,7 +2268,7 @@
         <boolean name="carrier_vt_available_bool" value="true" />
         <boolean name="carrier_use_ims_first_for_emergency_bool" value="true" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="editable_wfc_mode_bool" value="false" />
         <boolean name="carrier_name_override_bool" value="false" />
         <string name="carrier_name_string" />
@@ -2280,7 +2280,7 @@
         <boolean name="carrier_vt_available_bool" value="true" />
         <boolean name="carrier_use_ims_first_for_emergency_bool" value="true" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="editable_wfc_mode_bool" value="false" />
         <boolean name="carrier_name_override_bool" value="false" />
         <string name="carrier_name_string" />
@@ -2292,7 +2292,7 @@
         <boolean name="carrier_vt_available_bool" value="true" />
         <boolean name="carrier_use_ims_first_for_emergency_bool" value="true" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="editable_wfc_mode_bool" value="false" />
         <boolean name="carrier_name_override_bool" value="false" />
         <string name="carrier_name_string" />
@@ -2304,7 +2304,7 @@
         <boolean name="carrier_vt_available_bool" value="true" />
         <boolean name="carrier_use_ims_first_for_emergency_bool" value="true" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="editable_wfc_mode_bool" value="false" />
         <boolean name="carrier_name_override_bool" value="false" />
         <string name="carrier_name_string" />
@@ -2316,7 +2316,7 @@
         <boolean name="carrier_vt_available_bool" value="true" />
         <boolean name="carrier_use_ims_first_for_emergency_bool" value="true" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="editable_wfc_mode_bool" value="false" />
         <boolean name="carrier_name_override_bool" value="false" />
         <string name="carrier_name_string" />
@@ -2328,7 +2328,7 @@
         <boolean name="carrier_vt_available_bool" value="true" />
         <boolean name="carrier_use_ims_first_for_emergency_bool" value="true" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="editable_wfc_mode_bool" value="false" />
         <boolean name="carrier_name_override_bool" value="false" />
         <string name="carrier_name_string" />
@@ -2340,7 +2340,7 @@
         <boolean name="carrier_vt_available_bool" value="true" />
         <boolean name="carrier_use_ims_first_for_emergency_bool" value="true" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="editable_wfc_mode_bool" value="false" />
         <boolean name="carrier_name_override_bool" value="false" />
         <string name="carrier_name_string" />
@@ -2352,7 +2352,7 @@
         <boolean name="carrier_vt_available_bool" value="true" />
         <boolean name="carrier_use_ims_first_for_emergency_bool" value="true" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="editable_wfc_mode_bool" value="false" />
         <boolean name="carrier_name_override_bool" value="false" />
         <string name="carrier_name_string" />
@@ -2364,7 +2364,7 @@
         <boolean name="carrier_vt_available_bool" value="true" />
         <boolean name="carrier_use_ims_first_for_emergency_bool" value="true" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="editable_wfc_mode_bool" value="false" />
         <boolean name="carrier_name_override_bool" value="false" />
         <string name="carrier_name_string" />
@@ -2376,7 +2376,7 @@
         <boolean name="carrier_vt_available_bool" value="true" />
         <boolean name="carrier_use_ims_first_for_emergency_bool" value="true" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="editable_wfc_mode_bool" value="false" />
         <boolean name="carrier_name_override_bool" value="false" />
         <string name="carrier_name_string" />
@@ -2388,7 +2388,7 @@
         <boolean name="carrier_vt_available_bool" value="true" />
         <boolean name="carrier_use_ims_first_for_emergency_bool" value="true" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="editable_wfc_mode_bool" value="false" />
         <boolean name="carrier_name_override_bool" value="false" />
         <string name="carrier_name_string" />
@@ -2400,7 +2400,7 @@
         <boolean name="carrier_vt_available_bool" value="true" />
         <boolean name="carrier_use_ims_first_for_emergency_bool" value="true" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="editable_wfc_mode_bool" value="false" />
         <boolean name="carrier_name_override_bool" value="false" />
         <string name="carrier_name_string" />
@@ -2412,7 +2412,7 @@
         <boolean name="carrier_vt_available_bool" value="true" />
         <boolean name="carrier_use_ims_first_for_emergency_bool" value="true" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="editable_wfc_mode_bool" value="false" />
         <boolean name="carrier_name_override_bool" value="false" />
         <string name="carrier_name_string" />
@@ -2424,7 +2424,7 @@
         <boolean name="carrier_vt_available_bool" value="true" />
         <boolean name="carrier_use_ims_first_for_emergency_bool" value="true" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="editable_wfc_mode_bool" value="false" />
         <boolean name="carrier_name_override_bool" value="false" />
         <string name="carrier_name_string" />
@@ -2436,7 +2436,7 @@
         <boolean name="carrier_vt_available_bool" value="true" />
         <boolean name="carrier_use_ims_first_for_emergency_bool" value="true" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="editable_wfc_mode_bool" value="false" />
         <boolean name="carrier_name_override_bool" value="false" />
         <string name="carrier_name_string" />
@@ -2448,7 +2448,7 @@
         <boolean name="carrier_vt_available_bool" value="true" />
         <boolean name="carrier_use_ims_first_for_emergency_bool" value="true" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="editable_wfc_mode_bool" value="false" />
         <boolean name="carrier_name_override_bool" value="false" />
         <string name="carrier_name_string" />
@@ -2460,7 +2460,7 @@
         <boolean name="carrier_vt_available_bool" value="true" />
         <boolean name="carrier_use_ims_first_for_emergency_bool" value="true" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="editable_wfc_mode_bool" value="false" />
         <boolean name="carrier_name_override_bool" value="false" />
         <string name="carrier_name_string" />
@@ -2472,7 +2472,7 @@
         <boolean name="carrier_vt_available_bool" value="true" />
         <boolean name="carrier_use_ims_first_for_emergency_bool" value="true" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="editable_wfc_mode_bool" value="false" />
         <boolean name="carrier_name_override_bool" value="false" />
         <string name="carrier_name_string" />
@@ -2484,7 +2484,7 @@
         <boolean name="carrier_vt_available_bool" value="true" />
         <boolean name="carrier_use_ims_first_for_emergency_bool" value="true" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="editable_wfc_mode_bool" value="false" />
         <boolean name="carrier_name_override_bool" value="false" />
         <string name="carrier_name_string" />
@@ -2495,49 +2495,49 @@
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
         <boolean name="carrier_vt_available_bool" value="true" />
         <boolean name="editable_wfc_mode_bool" value="false" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="405" mnc="52">
         <boolean name="carrier_volte_available_bool" value="true" />
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
         <boolean name="carrier_vt_available_bool" value="true" />
         <boolean name="editable_wfc_mode_bool" value="false" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="405" mnc="53">
         <boolean name="carrier_volte_available_bool" value="true" />
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
         <boolean name="carrier_vt_available_bool" value="true" />
         <boolean name="editable_wfc_mode_bool" value="false" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="405" mnc="54">
         <boolean name="carrier_volte_available_bool" value="true" />
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
         <boolean name="carrier_vt_available_bool" value="true" />
         <boolean name="editable_wfc_mode_bool" value="false" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="405" mnc="55">
         <boolean name="carrier_volte_available_bool" value="true" />
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
         <boolean name="carrier_vt_available_bool" value="true" />
         <boolean name="editable_wfc_mode_bool" value="false" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="405" mnc="56">
         <boolean name="carrier_volte_available_bool" value="true" />
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
         <boolean name="carrier_vt_available_bool" value="true" />
         <boolean name="editable_wfc_mode_bool" value="false" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="405" mnc="66">
         <boolean name="carrier_volte_available_bool" value="true" />
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
         <boolean name="carrier_vt_available_bool" value="true" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="editable_wfc_mode_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="405" mnc="67">
@@ -2545,7 +2545,7 @@
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
         <boolean name="carrier_vt_available_bool" value="true" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="editable_wfc_mode_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="405" mnc="750">
@@ -2553,7 +2553,7 @@
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
         <boolean name="carrier_vt_available_bool" value="true" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="editable_wfc_mode_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="405" mnc="751">
@@ -2561,7 +2561,7 @@
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
         <boolean name="carrier_vt_available_bool" value="true" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="editable_wfc_mode_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="405" mnc="752">
@@ -2569,7 +2569,7 @@
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
         <boolean name="carrier_vt_available_bool" value="true" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="editable_wfc_mode_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="405" mnc="753">
@@ -2577,7 +2577,7 @@
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
         <boolean name="carrier_vt_available_bool" value="true" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="editable_wfc_mode_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="405" mnc="754">
@@ -2585,7 +2585,7 @@
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
         <boolean name="carrier_vt_available_bool" value="true" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="editable_wfc_mode_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="405" mnc="755">
@@ -2593,7 +2593,7 @@
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
         <boolean name="carrier_vt_available_bool" value="true" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="editable_wfc_mode_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="405" mnc="756">
@@ -2601,7 +2601,7 @@
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
         <boolean name="carrier_vt_available_bool" value="true" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="editable_wfc_mode_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="405" mnc="70">
@@ -2609,7 +2609,7 @@
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
         <boolean name="carrier_vt_available_bool" value="true" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="editable_wfc_mode_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="405" mnc="799">
@@ -2617,7 +2617,7 @@
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
         <boolean name="carrier_vt_available_bool" value="true" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="editable_wfc_mode_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="405" mnc="845">
@@ -2625,7 +2625,7 @@
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
         <boolean name="carrier_vt_available_bool" value="true" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="editable_wfc_mode_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="405" mnc="846">
@@ -2633,7 +2633,7 @@
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
         <boolean name="carrier_vt_available_bool" value="true" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="editable_wfc_mode_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="405" mnc="847">
@@ -2646,7 +2646,7 @@
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
         <boolean name="carrier_vt_available_bool" value="true" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="editable_wfc_mode_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="405" mnc="849">
@@ -2654,7 +2654,7 @@
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
         <boolean name="carrier_vt_available_bool" value="true" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="editable_wfc_mode_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="405" mnc="850">
@@ -2662,7 +2662,7 @@
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
         <boolean name="carrier_vt_available_bool" value="true" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="editable_wfc_mode_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="405" mnc="851">
@@ -2675,7 +2675,7 @@
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
         <boolean name="carrier_vt_available_bool" value="true" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="editable_wfc_mode_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="405" mnc="853">
@@ -2683,7 +2683,7 @@
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
         <boolean name="carrier_vt_available_bool" value="true" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="editable_wfc_mode_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="405" mnc="908">
@@ -2726,7 +2726,7 @@
     </carrier_config>
     <carrier_config mcc="413" mnc="5">
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="414" mnc="09">
         <boolean name="carrier_volte_available_bool" value="true" />
@@ -2739,7 +2739,7 @@
     </carrier_config>
     <carrier_config mcc="416" mnc="3">
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="419" mnc="02">
         <boolean name="carrier_volte_available_bool" value="true" />
@@ -2757,30 +2757,30 @@
     </carrier_config>
     <carrier_config mcc="419" mnc="3">
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="419" mnc="4">
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="420" mnc="04">
         <boolean name="carrier_volte_available_bool" value="true" />
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
         <boolean name="show_ims_registration_status_bool" value="true" />
     </carrier_config>
     <carrier_config mcc="420" mnc="01">
         <boolean name="carrier_volte_available_bool" value="true" />
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
         <boolean name="show_ims_registration_status_bool" value="true" />
     </carrier_config>
     <carrier_config mcc="420" mnc="03">
         <boolean name="carrier_volte_available_bool" value="true" />
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
         <boolean name="show_ims_registration_status_bool" value="true" />
     </carrier_config>
@@ -2827,18 +2827,18 @@
     </carrier_config>
     <carrier_config mcc="425" mnc="2">
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="425" mnc="1">
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="425" mnc="3">
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="425" mnc="7">
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="426" mnc="01">
         <boolean name="carrier_volte_available_bool" value="true" />
@@ -2865,7 +2865,7 @@
     </carrier_config>
     <carrier_config mcc="429" mnc="1">
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="440" mnc="11">
         <boolean name="carrier_volte_available_bool" value="true" />
@@ -3066,11 +3066,11 @@
         <boolean name="carrier_volte_available_bool" value="true" />
     </carrier_config>
     <carrier_config mcc="452" mnc="4">
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
     </carrier_config>
     <carrier_config mcc="452" mnc="2">
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
     </carrier_config>
     <carrier_config mcc="454" mnc="07">
@@ -3220,12 +3220,12 @@
     <carrier_config mcc="466" mnc="92">
         <boolean name="carrier_volte_available_bool" value="true" />
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="466" mnc="11">
         <boolean name="carrier_volte_available_bool" value="true" />
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="466" mnc="01">
         <boolean name="carrier_volte_available_bool" value="true" />
@@ -3253,7 +3253,7 @@
         <boolean name="call_forwarding_when_unreachable_supported_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="466" mnc="5">
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="call_forwarding_when_unreachable_supported_bool" value="false" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
         <int name="wfc_spn_format_idx_int" value="1" />
@@ -3273,7 +3273,7 @@
         <boolean name="carrier_volte_available_bool" value="true" />
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="502" mnc="18">
         <boolean name="carrier_volte_available_bool" value="true" />
@@ -3284,14 +3284,14 @@
     <carrier_config mcc="502" mnc="153">
         <boolean name="carrier_volte_available_bool" value="true" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="502" mnc="12">
         <boolean name="carrier_volte_available_bool" value="true" />
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
         <boolean name="carrier_vt_available_bool" value="true" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="502" mnc="19">
         <boolean name="carrier_volte_available_bool" value="true" />
@@ -3312,7 +3312,7 @@
         <boolean name="hide_enhanced_4g_lte_bool" value="true" />
         <boolean name="enhanced_4g_lte_on_by_default_bool" value="true" />
         <boolean name="display_hd_audio_property_bool" value="false" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="505" mnc="2">
         <boolean name="hide_enhanced_4g_lte_bool" value="true" />
@@ -3355,12 +3355,12 @@
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
     </carrier_config>
     <carrier_config mcc="515" mnc="2">
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
     </carrier_config>
     <carrier_config mcc="515" mnc="3">
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="520" mnc="03">
         <boolean name="carrier_volte_available_bool" value="true" />
@@ -3393,7 +3393,7 @@
     <carrier_config mcc="520" mnc="17">
         <boolean name="carrier_volte_available_bool" value="true" />
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
     </carrier_config>
     <carrier_config mcc="520" mnc="15">
@@ -3416,14 +3416,14 @@
         <boolean name="carrier_use_ims_first_for_emergency_bool" value="true" />
     </carrier_config>
     <carrier_config mcc="525" mnc="5">
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
     </carrier_config>
     <carrier_config mcc="525" mnc="1">
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
     </carrier_config>
     <carrier_config mcc="530" mnc="5">
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="530" mnc="24">
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
@@ -3471,7 +3471,7 @@
     </carrier_config>
     <carrier_config mcc="639" mnc="2">
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="647" mnc="00">
         <boolean name="carrier_volte_available_bool" value="true" />
@@ -3512,7 +3512,7 @@
     </carrier_config>
     <carrier_config mcc="655" mnc="2">
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="704" mnc="02">
         <boolean name="carrier_volte_available_bool" value="true" />
@@ -3521,7 +3521,7 @@
         <boolean name="carrier_volte_available_bool" value="true" />
         <string name="default_vm_number_string">*80</string>
         <boolean name="editable_voicemail_number_setting_bool" value="false" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="is_ims_conference_size_enforced_bool" value="true" />
         <int name="ims_conference_size_limit_int" value="6" />
         <boolean name="display_hd_audio_property_bool" value="false" />
@@ -3537,14 +3537,14 @@
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
         <string name="default_vm_number_string">*80</string>
         <boolean name="editable_voicemail_number_setting_bool" value="false" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="is_ims_conference_size_enforced_bool" value="true" />
         <int name="ims_conference_size_limit_int" value="6" />
         <boolean name="display_hd_audio_property_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="704" mnc="2">
         <boolean name="editable_voicemail_number_setting_bool" value="false" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <string name="default_vm_number_string">*77</string>
     </carrier_config>
     <carrier_config mcc="706" mnc="01">
@@ -3554,7 +3554,7 @@
     <carrier_config mcc="706" mnc="1">
         <string name="default_vm_number_string">*80</string>
         <boolean name="editable_voicemail_number_setting_bool" value="false" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="is_ims_conference_size_enforced_bool" value="true" />
         <int name="ims_conference_size_limit_int" value="6" />
         <boolean name="display_hd_audio_property_bool" value="false" />
@@ -3566,7 +3566,7 @@
     <carrier_config mcc="708" mnc="1">
         <string name="default_vm_number_string">*80</string>
         <boolean name="editable_voicemail_number_setting_bool" value="false" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="is_ims_conference_size_enforced_bool" value="true" />
         <int name="ims_conference_size_limit_int" value="6" />
         <boolean name="display_hd_audio_property_bool" value="false" />
@@ -3575,7 +3575,7 @@
         <boolean name="carrier_volte_available_bool" value="true" />
         <string name="default_vm_number_string">*80</string>
         <boolean name="editable_voicemail_number_setting_bool" value="false" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="is_ims_conference_size_enforced_bool" value="true" />
         <int name="ims_conference_size_limit_int" value="6" />
         <boolean name="display_hd_audio_property_bool" value="false" />
@@ -3585,7 +3585,7 @@
     </carrier_config>
     <carrier_config mcc="710" mnc="73">
         <boolean name="display_hd_audio_property_bool" value="false" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="712" mnc="03">
         <boolean name="carrier_volte_available_bool" value="true" />
@@ -3594,7 +3594,7 @@
     <carrier_config mcc="712" mnc="3">
         <string name="default_vm_number_string">*80</string>
         <boolean name="editable_voicemail_number_setting_bool" value="false" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="is_ims_conference_size_enforced_bool" value="true" />
         <int name="ims_conference_size_limit_int" value="6" />
         <boolean name="display_hd_audio_property_bool" value="false" />
@@ -3606,7 +3606,7 @@
     <carrier_config mcc="714" mnc="3">
         <string name="default_vm_number_string">*111</string>
         <boolean name="editable_voicemail_number_setting_bool" value="false" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="is_ims_conference_size_enforced_bool" value="true" />
         <int name="ims_conference_size_limit_int" value="6" />
         <boolean name="display_hd_audio_property_bool" value="false" />
@@ -3614,7 +3614,7 @@
     <carrier_config mcc="716" mnc="17">
         <boolean name="carrier_volte_available_bool" value="true" />
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="carrier_default_data_roaming_enabled_bool" value="true" />
         <boolean name="carrier_wfc_supports_wifi_only_bool" value="false" />
     </carrier_config>
@@ -3622,7 +3622,7 @@
         <boolean name="carrier_volte_available_bool" value="true" />
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
         <boolean name="carrier_vt_available_bool" value="true" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <string name="default_vm_number_string">131</string>
         <boolean name="editable_voicemail_number_setting_bool" value="false" />
         <boolean name="editable_wfc_mode_bool" value="false" />
@@ -3639,7 +3639,7 @@
     </carrier_config>
     <carrier_config mcc="716" mnc="6">
         <boolean name="carrier_default_data_roaming_enabled_bool" value="true" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <string-array name="unloggable_numbers_string_array" num="1">
             <item value="100" />
         </string-array>
@@ -3647,7 +3647,7 @@
     <carrier_config mcc="722" mnc="07">
         <boolean name="carrier_volte_available_bool" value="true" />
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <string-array name="unloggable_numbers_string_array" num="1">
             <item value="144" />
         </string-array>
@@ -3666,7 +3666,7 @@
         <boolean name="editable_enhanced_4g_lte_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="722" mnc="010">
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <string-array name="unloggable_numbers_string_array" num="1">
             <item value="144" />
         </string-array>
@@ -3787,7 +3787,7 @@
         <boolean name="carrier_vt_available_bool" value="true" />
     </carrier_config>
     <carrier_config mcc="730" mnc="3">
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="editable_wfc_mode_bool" value="false" />
         <string-array name="non_roaming_operator_string_array" num="5">
             <item value="73001" />
@@ -3814,7 +3814,7 @@
     </carrier_config>
     <carrier_config mcc="730" mnc="9">
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <string-array name="non_roaming_operator_string_array" num="4">
             <item value="73001" />
             <item value="73002" />
@@ -3822,18 +3822,18 @@
             <item value="73021" />
         </string-array>
         <string name="default_vm_number_string">+56964109999</string>
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
         <boolean name="call_barring_visibility_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="730" mnc="1">
         <boolean name="call_barring_visibility_bool" value="false" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="carrier_default_data_roaming_enabled_bool" value="true" />
     </carrier_config>
     <carrier_config mcc="732" mnc="111">
         <boolean name="carrier_volte_available_bool" value="true" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
         <string name="default_vm_number_string">*123</string>
         <boolean name="carrier_default_data_roaming_enabled_bool" value="true" />
@@ -3841,7 +3841,7 @@
     </carrier_config>
     <carrier_config mcc="732" mnc="103">
         <boolean name="carrier_volte_available_bool" value="true" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
         <string name="default_vm_number_string">*123</string>
         <boolean name="carrier_default_data_roaming_enabled_bool" value="true" />
@@ -3852,13 +3852,13 @@
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
         <string name="default_vm_number_string">*123</string>
         <boolean name="voicemail_notification_persistent_bool" value="true" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
     </carrier_config>
     <carrier_config mcc="732" mnc="101">
         <boolean name="carrier_volte_available_bool" value="true" />
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
         <boolean name="carrier_vt_available_bool" value="true" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <string name="default_vm_number_string">*123</string>
         <boolean name="editable_voicemail_number_setting_bool" value="false" />
         <boolean name="editable_wfc_mode_bool" value="false" />
@@ -3872,7 +3872,7 @@
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
         <boolean name="carrier_vt_available_bool" value="true" />
         <string name="default_vm_number_string">*123</string>
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
     </carrier_config>
     <carrier_config mcc="732" mnc="360">
@@ -3880,11 +3880,11 @@
         <boolean name="carrier_wfc_ims_available_bool" value="false" />
         <boolean name="carrier_vt_available_bool" value="true" />
         <string name="default_vm_number_string">*123</string>
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
     </carrier_config>
     <carrier_config mcc="732" mnc="165">
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
         <string name="default_vm_number_string">*123</string>
         <boolean name="carrier_default_data_roaming_enabled_bool" value="true" />
@@ -3913,7 +3913,7 @@
     <carrier_config mcc="740" mnc="1">
         <string name="default_vm_number_string">#99</string>
         <boolean name="editable_voicemail_number_setting_bool" value="false" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="is_ims_conference_size_enforced_bool" value="true" />
         <int name="ims_conference_size_limit_int" value="6" />
         <boolean name="display_hd_audio_property_bool" value="false" />
@@ -3921,7 +3921,7 @@
     <carrier_config mcc="744" mnc="2">
         <string name="default_vm_number_string">*555</string>
         <boolean name="editable_voicemail_number_setting_bool" value="false" />
-        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="false" />
         <boolean name="is_ims_conference_size_enforced_bool" value="true" />
         <int name="ims_conference_size_limit_int" value="6" />
         <boolean name="display_hd_audio_property_bool" value="false" />


### PR DESCRIPTION
* its useless to disable `carrier_wfc_ims_available_bool` without disabling `carrier_default_wfc_ims_enabled_bool`